### PR TITLE
Adds notice that git is neccessary for degit

### DIFF
--- a/content/Introduction to Svelte.md
+++ b/content/Introduction to Svelte.md
@@ -24,7 +24,7 @@ Node installs the [`npx`](https://flaviocopes.com/npx/) command, which is a hand
 npx degit sveltejs/template firstapp
 ```
 
-This will download and run the [degit command](https://github.com/Rich-Harris/degit), which in turn downloads the latest code of the Svelte project template living at [https://github.com/sveltejs/template](https://github.com/sveltejs/template), into the `firstapp` folder.
+This will download and run the [degit command](https://github.com/Rich-Harris/degit), which in turn downloads the latest code of the Svelte project template living at [https://github.com/sveltejs/template](https://github.com/sveltejs/template), into a newly created `firstapp` folder. Make sure that [git is installed](https://git-scm.com/download) on your machine and added to the PATH variable, otherwise the degit command won't work. In case, things are still not working out for you, you can alternatively 'Clone or download' the template project and afterwards delete the hidden `.git` folder, which is basically the same what the `degit` command does (only difference is that the folder is called `template` instead of `firstapp`).
 
 Now go into that `firstapp` folder and run `npm install` to download the additional dependencies of the template. At the time of writing, those are the dependencies of that project template:
 


### PR DESCRIPTION
I ran the `npx degit ...` command on a new Win 10 machine with freshly installed node and had a degit/git error.
```
! could not find commit hash for master
```
It seems like degit uses git under the hood and therefore needs it to be installed (https://github.com/Rich-Harris/degit/issues/37).
I added a short pararagraph explaining this and also an alternative to using degit.
In my opinion the process of setting up a new project with new technologies should be as hassle-free as possible. This can easily throw newbies off before even really starting.

Secondly, I would also suggest to mention that `npm run dev` starts a **hot** development server which updates any saved `src` file changes immediatily visible in the browser. Would be nice to now that this is already set up by the svelte template, so that playing around with the code can get started ;)

At the very end of the article after the `App.svelte` is introduced, a recommended Visual Studio code extensions for syntax highlighting of svelte would be nice imo.